### PR TITLE
Changed reset into self destruct

### DIFF
--- a/src/controls.cpp
+++ b/src/controls.cpp
@@ -9,7 +9,7 @@ Controls::Controls(int index)
 , primary_action("primary_action" + sp::string(index))
 , secondary_action("secondary_action" + sp::string(index))
 , unknown2("unknown2_" + sp::string(index))
-, restart("restart_" + sp::string(index))
+, self_destruct("self_destruct_" + sp::string(index))
 , unknown4("unknown4_" + sp::string(index))
 , unknown5("unknown5_" + sp::string(index))
 , start("start" + sp::string(index))
@@ -25,7 +25,7 @@ Controls::Controls(int index)
         secondary_action.setKey("z");
         
         unknown2.setKey("x");
-        restart.setKey("c");
+        self_destruct.setKey("c");
         unknown4.setKey("v");
         unknown5.setKey("b");
         
@@ -43,7 +43,7 @@ Controls::Controls(int index)
         secondary_action.setKey("e");
         
         unknown2.setKey("r");
-        restart.setKey("f");
+        self_destruct.setKey("f");
         unknown4.setKey("t");
         unknown5.setKey("g");
         

--- a/src/controls.h
+++ b/src/controls.h
@@ -19,7 +19,7 @@ public:
     sp::io::Keybinding secondary_action;
 
     sp::io::Keybinding unknown2;
-    sp::io::Keybinding restart;
+    sp::io::Keybinding self_destruct;
     sp::io::Keybinding unknown4;
     sp::io::Keybinding unknown5;
     

--- a/src/levelScene.cpp
+++ b/src/levelScene.cpp
@@ -190,10 +190,6 @@ void LevelScene::onFixedUpdate()
     {
         exitLevel();
     }
-    if ((controls[0].restart.getDown() || controls[1].restart.getDown()) && controls[0].restart.get() && controls[1].restart.get())
-    {
-        loadLevel(level_name);
-    }
 }
 
 void LevelScene::onUpdate(float delta)

--- a/src/spaceship.cpp
+++ b/src/spaceship.cpp
@@ -89,9 +89,9 @@ void Spaceship::onFixedUpdate()
                 rope.destroy();
             }
         }
-        if (controls->restart.getDown() && controls->restart.get())
+        if (controls->self_destruct.getDown())
         {
-            LOG(Debug, "RESET SELF DESTRUCT");
+            LOG(Debug, "Initiating self destruct for player", controls->index);
             explode();
         }
     }

--- a/src/spaceship.cpp
+++ b/src/spaceship.cpp
@@ -89,6 +89,11 @@ void Spaceship::onFixedUpdate()
                 rope.destroy();
             }
         }
+        if (controls->restart.getDown() && controls->restart.get())
+        {
+            LOG(Debug, "RESET SELF DESTRUCT");
+            explode();
+        }
     }
     
     setLinearVelocity(velocity);


### PR DESCRIPTION
I Changed reset into self destruct Because I find the reset very jarring, while a self destruct uses the timeout and visual cues (explosion, darker ship) already present allowing players to be ready for the restart.

Could also rename the button, but the meaning is still to reset the game so left it as is...?